### PR TITLE
Enabled multiple DM1 and DM2 messages to be read and written. 

### DIFF
--- a/Src/Open_SAE_J1939/Structs.h
+++ b/Src/Open_SAE_J1939/Structs.h
@@ -67,11 +67,11 @@ struct DM1 {
 	uint8_t SAE_flash_lamp_protect_lamp;
 
 	/* Fault location, problem and codes */
-	uint32_t SPN;									/* Location where the fault exist */
-	uint8_t FMI;									/* Type of problem */
-	uint8_t SPN_conversion_method;					/* If SPN_conversion_method = 1 that means Diagnostics Trouble Code are aligned using a newer conversion method. If SPN_conversion_method = 0 means one of the three Diagnostics Trouble Code conversion methods is used and ECU manufacture shall know which of the three methods is used */
-	uint8_t occurrence_count;						/* This tells how many times failure has occurred. Every time fault goes from inactive to active, the occurence_count is incremented by 1. If fault becomes active for more than 126 times the occurence_count remains 126 */
-	uint8_t from_ecu_address;						/* From which ECU came this message */
+	uint32_t SPN [10];									/* Location where the fault exist */
+	uint8_t FMI [10];									/* Type of problem */
+	uint8_t SPN_conversion_method [10];					/* If SPN_conversion_method = 1 that means Diagnostics Trouble Code are aligned using a newer conversion method. If SPN_conversion_method = 0 means one of the three Diagnostics Trouble Code conversion methods is used and ECU manufacture shall know which of the three methods is used */
+	uint8_t occurrence_count [10];						/* This tells how many times failure has occurred. Every time fault goes from inactive to active, the occurence_count is incremented by 1. If fault becomes active for more than 126 times the occurence_count remains 126 */
+	uint8_t from_ecu_address [10];						/* From which ECU came this message */
 };
 
 /* PGN: 0x00D800 - Storing the DM15 response from the reading process */

--- a/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
+++ b/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
@@ -48,10 +48,10 @@ void SAE_J1939_Read_Transport_Protocol_Data_Transfer(J1939 *j1939, uint8_t SA, u
 		SAE_J1939_Read_Commanded_Address(j1939, complete_data);								/* Insert new name and new address to this ECU */
 		break;
 	case PGN_DM1:
-		SAE_J1939_Read_Response_Request_DM1(j1939, SA, complete_data, complete_data[8]); 	/* Sequence number is the last index */
+		SAE_J1939_Read_Response_Request_DM1(j1939, SA, complete_data, (total_message_size-2)/4); 	/* Number of DTCs = 4 bytes per DTC excluding 2 bytes for the lamp */
 		break;
 	case PGN_DM2:
-		SAE_J1939_Read_Response_Request_DM2(j1939, SA, complete_data, complete_data[8]); 	/* Sequence number is the last index */
+		SAE_J1939_Read_Response_Request_DM2(j1939, SA, complete_data, (total_message_size-2)/4); 	/* Number of DTCs = 4 bytes per DTC excluding 2 bytes for the lamp */
 		break;
 	case PGN_DM16:
 		SAE_J1939_Read_Binary_Data_Transfer_DM16(j1939, SA, complete_data);

--- a/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM1.c
+++ b/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM1.c
@@ -29,26 +29,29 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM1(J1939* j1939, uint8_t DA)
 		uint8_t data[8];
 		data[0] = (j1939->this_dm.dm1.SAE_lamp_status_malfunction_indicator << 6) | (j1939->this_dm.dm1.SAE_lamp_status_red_stop << 4) | (j1939->this_dm.dm1.SAE_lamp_status_amber_warning << 2) | (j1939->this_dm.dm1.SAE_lamp_status_protect_lamp);
 		data[1] = (j1939->this_dm.dm1.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm1.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm1.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm1.SAE_flash_lamp_protect_lamp);
-		data[2] = j1939->this_dm.dm1.SPN;
-		data[3] = j1939->this_dm.dm1.SPN >> 8;
-		data[4] = ((j1939->this_dm.dm1.SPN >> 11) & 0b11100000) | j1939->this_dm.dm1.FMI;
-		data[5] = (j1939->this_dm.dm1.SPN_conversion_method << 7) | j1939->this_dm.dm1.occurrence_count;
+		data[2] = j1939->this_dm.dm1.SPN[1];
+		data[3] = j1939->this_dm.dm1.SPN[1] >> 8;
+		data[4] = ((j1939->this_dm.dm1.SPN[1] >> 11) & 0b11100000) | j1939->this_dm.dm1.FMI[1];
+		data[5] = (j1939->this_dm.dm1.SPN_conversion_method[1] << 7) | j1939->this_dm.dm1.occurrence_count[1];
 		data[6] = 0xFF;													/* Reserved */
 		data[7] = 0xFF;													/* Reserved */
 		return CAN_Send_Message(ID, data);
 	} else {
 		/* Multiple messages - Load data */
-		j1939->this_ecu_tp_cm.number_of_packages = 2;
-		j1939->this_ecu_tp_cm.total_message_size = 9;
+		j1939->this_ecu_tp_cm.total_message_size = (j1939->this_dm.errors_dm1_active *4) +2 ;				/* set total message size where each DTC is 4 btyes, plus 2 bytes for the lamp code */
+		j1939->this_ecu_tp_cm.number_of_packages = (j1939->this_ecu_tp_cm.total_message_size)/7;			/* set number of packages, where each package will transmit up to 7 bytes */
+		if (j1939->this_ecu_tp_cm.total_message_size % 7 > 0) j1939->this_ecu_tp_cm.number_of_packages++;	/* add extra frame if data rolls over */
+
+		/* Load lamp data to first two bytes */
 		j1939->this_ecu_tp_dt.data[0] = (j1939->this_dm.dm1.SAE_lamp_status_malfunction_indicator << 6) | (j1939->this_dm.dm1.SAE_lamp_status_red_stop << 4) | (j1939->this_dm.dm1.SAE_lamp_status_amber_warning << 2) | (j1939->this_dm.dm1.SAE_lamp_status_protect_lamp);
 		j1939->this_ecu_tp_dt.data[1] = (j1939->this_dm.dm1.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm1.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm1.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm1.SAE_flash_lamp_protect_lamp);
-		j1939->this_ecu_tp_dt.data[2] = j1939->this_dm.dm1.SPN;
-		j1939->this_ecu_tp_dt.data[3] = j1939->this_dm.dm1.SPN >> 8;
-		j1939->this_ecu_tp_dt.data[4] = ((j1939->this_dm.dm1.SPN >> 11) & 0b11100000) | j1939->this_dm.dm1.FMI;
-		j1939->this_ecu_tp_dt.data[5] = (j1939->this_dm.dm1.SPN_conversion_method << 7) | j1939->this_dm.dm1.occurrence_count;
-		j1939->this_ecu_tp_dt.data[6] = 0xFF;													/* Reserved */
-		j1939->this_ecu_tp_dt.data[7] = 0xFF;													/* Reserved */
-		j1939->this_ecu_tp_dt.data[8] = j1939->this_dm.errors_dm1_active;
+		/* Load DTCs into TP data package */
+		for (uint8_t i = 0; i < j1939->this_ecu_tp_cm.total_message_size; i=i++){
+			j1939->this_ecu_tp_dt.data[i*4 + 2] = j1939->this_dm.dm1.SPN[i];
+			j1939->this_ecu_tp_dt.data[i*4 + 3] = j1939->this_dm.dm1.SPN[i] >> 8;
+			j1939->this_ecu_tp_dt.data[i*4 + 4] = ((j1939->this_dm.dm1.SPN[i] >> 11) & 0b11100000) | j1939->this_dm.dm1.FMI[i];
+			j1939->this_ecu_tp_dt.data[i*4 + 5] = (j1939->this_dm.dm1.SPN_conversion_method[i] << 7) | j1939->this_dm.dm1.occurrence_count[i];
+		}
 
 		/* Send TP CM */
 		j1939->this_ecu_tp_cm.PGN_of_the_packeted_message = PGN_DM1;
@@ -69,6 +72,11 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM1(J1939* j1939, uint8_t DA)
  * PGN: 0x00FECA (65226)
  */
 void SAE_J1939_Read_Response_Request_DM1(J1939 *j1939, uint8_t SA, uint8_t data[], uint8_t errors_dm1_active) {
+	/*iF there are fewer active DTCs than previous, clear the list so old DTCs do not remain after parsing the new ones*/
+	if (errors_dm1_active < j1939->from_other_ecu_dm.errors_dm1_active) {
+		memset(&j1939->from_other_ecu_dm.dm1.SPN, 0, sizeof(j1939->from_other_ecu_dm.dm1.SPN)); 	/* This set all fields of dm1 to 0 */
+	}
+
 	j1939->from_other_ecu_dm.dm1.SAE_lamp_status_malfunction_indicator = data[0] >> 6;
 	j1939->from_other_ecu_dm.dm1.SAE_lamp_status_red_stop = (data[0] >> 4) & 0b00000011;
 	j1939->from_other_ecu_dm.dm1.SAE_lamp_status_amber_warning = (data[0] >> 2) & 0b00000011;
@@ -77,15 +85,24 @@ void SAE_J1939_Read_Response_Request_DM1(J1939 *j1939, uint8_t SA, uint8_t data[
 	j1939->from_other_ecu_dm.dm1.SAE_flash_lamp_red_stop = (data[1] >> 4) & 0b00000011;
 	j1939->from_other_ecu_dm.dm1.SAE_flash_lamp_amber_warning = (data[1] >> 2) & 0b00000011;
 	j1939->from_other_ecu_dm.dm1.SAE_flash_lamp_protect_lamp = data[1] & 0b00000011;
-	j1939->from_other_ecu_dm.dm1.SPN = ((data[4] & 0b11100000) << 11) | (data[3] << 8) | data[2];
-	j1939->from_other_ecu_dm.dm1.FMI = data[4] & 0b00011111;
-	j1939->from_other_ecu_dm.dm1.SPN_conversion_method = data[5] >> 7;
-	j1939->from_other_ecu_dm.dm1.occurrence_count = data[5] & 0b01111111;
-	j1939->from_other_ecu_dm.dm1.from_ecu_address = SA;
 
-	/* Check if we have no fault cause */
-	if(j1939->from_other_ecu_dm.dm1.FMI == FMI_NOT_AVAILABLE)
+	/*Read and Decode DTC info for up to 10 active DTCs*/
+	for (uint8_t i = 0; i < errors_dm1_active && i < 10; i++){
+		j1939->from_other_ecu_dm.dm1.SPN[i] = ((data[(i*4)+4] & 0b11100000) << 11) | (data[(i*4)+3] << 8) | data[(i*4)+2];
+		j1939->from_other_ecu_dm.dm1.FMI[i] = data[(i*4)+4] & 0b00011111;
+		j1939->from_other_ecu_dm.dm1.SPN_conversion_method[i] = data[(i*4)+5] >> 7;
+		j1939->from_other_ecu_dm.dm1.occurrence_count[i] = data[(i*4)+5] & 0b01111111;
+		j1939->from_other_ecu_dm.dm1.from_ecu_address[i] = SA;
+	}
+
+
+	/* Check if we have no fault cause 
+	 * When there is a single DM1 code, and the SPN is 0, this signals all DM1 messages have cleared and no active messages are left
+	 */
+	if (errors_dm1_active == 1 && j1939->from_other_ecu_dm.dm1.SPN == 0) {
 		j1939->from_other_ecu_dm.errors_dm1_active = 0;
-	else
+	} else if (j1939->from_other_ecu_dm.errors_dm1_active > errors_dm1_active) {
 		j1939->from_other_ecu_dm.errors_dm1_active = errors_dm1_active;
+	}
+
 }

--- a/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM2.c
+++ b/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM2.c
@@ -29,26 +29,29 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM2(J1939 *j1939, uint8_t DA)
 		uint8_t data[8];
 		data[0] = (j1939->this_dm.dm2.SAE_lamp_status_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_lamp_status_red_stop << 4) | (j1939->this_dm.dm2.SAE_lamp_status_amber_warning << 2) | (j1939->this_dm.dm2.SAE_lamp_status_protect_lamp);
 		data[1] = (j1939->this_dm.dm2.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm2.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm2.SAE_flash_lamp_protect_lamp);
-		data[2] = j1939->this_dm.dm2.SPN;
-		data[3] = j1939->this_dm.dm2.SPN >> 8;
-		data[4] = ((j1939->this_dm.dm2.SPN >> 11) & 0b11100000) | j1939->this_dm.dm2.FMI;
-		data[5] = (j1939->this_dm.dm2.SPN_conversion_method << 7) | j1939->this_dm.dm2.occurrence_count;
+		data[2] = j1939->this_dm.dm2.SPN[1];
+		data[3] = j1939->this_dm.dm2.SPN[1] >> 8;
+		data[4] = ((j1939->this_dm.dm2.SPN[1] >> 11) & 0b11100000) | j1939->this_dm.dm2.FMI[1];
+		data[5] = (j1939->this_dm.dm2.SPN_conversion_method[1] << 7) | j1939->this_dm.dm2.occurrence_count[1];
 		data[6] = 0xFF;													/* Reserved */
 		data[7] = 0xFF;													/* Reserved */
 		return CAN_Send_Message(ID, data);
 	} else {
 		/* Multiple messages - Load data */
-		j1939->this_ecu_tp_cm.number_of_packages = 2;
-		j1939->this_ecu_tp_cm.total_message_size = 9;
+		j1939->this_ecu_tp_cm.total_message_size = (j1939->this_dm.errors_dm2_active *4) +2 ;				/* set total message size where each DTC is 4 btyes, plus 2 bytes for the lamp code */
+		j1939->this_ecu_tp_cm.number_of_packages = (j1939->this_ecu_tp_cm.total_message_size)/7;			/* set number of packages, where each package will transmit up to 7 bytes */
+		if (j1939->this_ecu_tp_cm.total_message_size % 7 > 0) j1939->this_ecu_tp_cm.number_of_packages++;	/* add extra frame if data rolls over */
+
+		/* Load lamp data to first two bytes */
 		j1939->this_ecu_tp_dt.data[0] = (j1939->this_dm.dm2.SAE_lamp_status_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_lamp_status_red_stop << 4) | (j1939->this_dm.dm2.SAE_lamp_status_amber_warning << 2) | (j1939->this_dm.dm2.SAE_lamp_status_protect_lamp);
 		j1939->this_ecu_tp_dt.data[1] = (j1939->this_dm.dm2.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm2.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm2.SAE_flash_lamp_protect_lamp);
-		j1939->this_ecu_tp_dt.data[2] = j1939->this_dm.dm2.SPN;
-		j1939->this_ecu_tp_dt.data[3] = j1939->this_dm.dm2.SPN >> 8;
-		j1939->this_ecu_tp_dt.data[4] = ((j1939->this_dm.dm2.SPN >> 11) & 0b11100000) | j1939->this_dm.dm2.FMI;
-		j1939->this_ecu_tp_dt.data[5] = (j1939->this_dm.dm2.SPN_conversion_method << 7) | j1939->this_dm.dm2.occurrence_count;
-		j1939->this_ecu_tp_dt.data[6] = 0xFF;													/* Reserved */
-		j1939->this_ecu_tp_dt.data[7] = 0xFF;													/* Reserved */
-		j1939->this_ecu_tp_dt.data[8] = j1939->this_dm.errors_dm2_active;
+		/* Load DTCs into TP data package */
+		for (uint8_t i = 0; i < j1939->this_ecu_tp_cm.total_message_size; i=i++){
+			j1939->this_ecu_tp_dt.data[i*4 + 2] = j1939->this_dm.dm2.SPN[i];
+			j1939->this_ecu_tp_dt.data[i*4 + 3] = j1939->this_dm.dm2.SPN[i] >> 8;
+			j1939->this_ecu_tp_dt.data[i*4 + 4] = ((j1939->this_dm.dm2.SPN[i] >> 11) & 0b11100000) | j1939->this_dm.dm2.FMI[i];
+			j1939->this_ecu_tp_dt.data[i*4 + 5] = (j1939->this_dm.dm2.SPN_conversion_method[i] << 7) | j1939->this_dm.dm2.occurrence_count[i];
+		}
 
 		/* Send TP CM */
 		j1939->this_ecu_tp_cm.PGN_of_the_packeted_message = PGN_DM2;
@@ -69,6 +72,12 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM2(J1939 *j1939, uint8_t DA)
  * PGN: 0x00FECB (65227)
  */
 void SAE_J1939_Read_Response_Request_DM2(J1939 *j1939, uint8_t SA, uint8_t data[], uint8_t errors_dm2_active) {
+	/* iF there are fewer active DTCs than previous, clear the list so old DTCs do not remain after parsing the new ones */
+	if (errors_dm2_active < j1939->from_other_ecu_dm.errors_dm2_active) {
+		memset(&j1939->from_other_ecu_dm.dm2.SPN, 0, sizeof(j1939->from_other_ecu_dm.dm2.SPN)); 	/* This set all fields of dm1 to 0 */
+	}
+
+	/* Decode lamp status */
 	j1939->from_other_ecu_dm.dm2.SAE_lamp_status_malfunction_indicator = data[0] >> 6;
 	j1939->from_other_ecu_dm.dm2.SAE_lamp_status_red_stop = (data[0] >> 4) & 0b00000011;
 	j1939->from_other_ecu_dm.dm2.SAE_lamp_status_amber_warning = (data[0] >> 2) & 0b00000011;
@@ -77,15 +86,20 @@ void SAE_J1939_Read_Response_Request_DM2(J1939 *j1939, uint8_t SA, uint8_t data[
 	j1939->from_other_ecu_dm.dm2.SAE_flash_lamp_red_stop = (data[1] >> 4) & 0b00000011;
 	j1939->from_other_ecu_dm.dm2.SAE_flash_lamp_amber_warning = (data[1] >> 2) & 0b00000011;
 	j1939->from_other_ecu_dm.dm2.SAE_flash_lamp_protect_lamp = data[1] & 0b00000011;
-	j1939->from_other_ecu_dm.dm2.SPN = ((data[4] & 0b11100000) << 11) | (data[3] << 8) | data[2];
-	j1939->from_other_ecu_dm.dm2.FMI = data[4] & 0b00011111;
-	j1939->from_other_ecu_dm.dm2.SPN_conversion_method = data[5] >> 7;
-	j1939->from_other_ecu_dm.dm2.occurrence_count = data[5] & 0b01111111;
-	j1939->from_other_ecu_dm.dm2.from_ecu_address = SA;
 
-	/* Check if we have no fault cause */
-	if(j1939->from_other_ecu_dm.dm2.FMI == FMI_NOT_AVAILABLE)
+	/* Read and Decode DTC info for up to 10 previously active DTCs */
+	for (uint8_t i = 0; i < errors_dm2_active && i < 10; i++){
+		j1939->from_other_ecu_dm.dm2.SPN[i] = ((data[(i*4)+4] & 0b11100000) << 11) | (data[(i*4)+3] << 8) | data[(i*4)+2];
+		j1939->from_other_ecu_dm.dm2.FMI[i] = data[(i*4)+4] & 0b00011111;
+		j1939->from_other_ecu_dm.dm2.SPN_conversion_method[i] = data[(i*4)+5] >> 7;
+		j1939->from_other_ecu_dm.dm2.occurrence_count[i] = data[(i*4)+5] & 0b01111111;
+		j1939->from_other_ecu_dm.dm2.from_ecu_address[i] = SA;
+	}
+
+	/* Assign number of DTCs in previously active list */
+	if (errors_dm2_active == 1 && j1939->from_other_ecu_dm.dm2.SPN == 0) {
 		j1939->from_other_ecu_dm.errors_dm2_active = 0;
-	else
+	} else if (j1939->from_other_ecu_dm.errors_dm2_active > errors_dm2_active) {
 		j1939->from_other_ecu_dm.errors_dm2_active = errors_dm2_active;
+	}
 }

--- a/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM3.c
+++ b/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM3.c
@@ -25,6 +25,6 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Send_Request_DM3(J1939 *j1939, uint8_t DA) {
 ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM3(J1939* j1939, uint8_t DA) {
 	memset(&j1939->this_dm.dm2, 0, sizeof(j1939->this_dm.dm2)); 		/* This set all fields of dm2 to 0 */
 	j1939->this_dm.errors_dm2_active = 0;
-	j1939->this_dm.dm2.FMI = FMI_NOT_AVAILABLE;							/* Important, else we will at least have 1 error active */
+																		/* Removed assigning FMI to 31.  Fixed DMx active message count to not rely on this value*/
 	return SAE_J1939_Response_Request_DM2(j1939, DA);					/* Send DM2 codes to the ECU who send the request */
 }


### PR DESCRIPTION
Updated J1939 Structure in Structs.h to have 10 element array for all DTCs so multiple values can be read and written
Fixed active DTC count calculation

Updated TP message formatting in DM1.c and DM2.c
 - Determines number of Active DTCs from other ECU from message size.  Calc automates active messages so relying on extra non standard byte with active count is not required.
 - Decodes DTCs with loop, stores up to 10 DTCs in J1939 data structure so multiple values can be evaluated
 - Calculates message size and frames for transport TP based on number of active this ECU DTCs
 - Adds ability to loads this_ecu_tp_dt.data structure with up to 10 DTCs from the local ecu

 Fixed detection of no-fault condition to match J1939 DM1 message standards (in DM1.c and DM2.c)
 - Sets active message count to 0 when DM1 message FECA contains a single DTC where all values are zero

Removed assignment of FMI to FMI_NOT_AVAILABLE (31) when requested to clear stored DM2 codes in DM3.c
 - FMI status of 31 is intended to be used as a general error condition if no other pre-defined FMI value applies
 - No longer required since DM1 and DM2 now use the standard all zero DTC message to indicate no active codes