### PR TITLE
TP.CM_RTS and TP.CM_CTS

### DIFF
--- a/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Connection_Management.c
+++ b/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Connection_Management.c
@@ -39,10 +39,19 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Send_Transport_Protocol_Connection_Management(
 	uint32_t ID = (0x1CEC << 16) | (DA << 8) | j1939->information_this_ECU.this_ECU_address;
 	uint8_t data[8] = { 0 };
 	data[0] = j1939->this_ecu_tp_cm.control_byte;
-	data[1] = j1939->this_ecu_tp_cm.total_message_size;
-	data[2] = j1939->this_ecu_tp_cm.total_message_size >> 8;
-	data[3] = j1939->this_ecu_tp_cm.number_of_packages;
-	data[4] = 0xFF; 															/* Reserved */
+	if (j1939->this_ecu_tp_cm.control_byte == CONTROL_BYTE_TP_CM_CTS)
+	{
+		data[1] = j1939->this_ecu_tp_cm.number_of_packages;
+		data[2] = 0x01;
+		data[3] = 0xFF; /* Reserved */
+	}
+	else // CONTROL_BYTE_TP_CM_RTS
+	{
+		data[1] = j1939->this_ecu_tp_cm.total_message_size;
+		data[2] = j1939->this_ecu_tp_cm.total_message_size >> 8;
+		data[3] = j1939->this_ecu_tp_cm.number_of_packages;
+	}
+	data[4] = 0xFF; /* Reserved */
 	data[5] = j1939->this_ecu_tp_cm.PGN_of_the_packeted_message;
 	data[6] = j1939->this_ecu_tp_cm.PGN_of_the_packeted_message >> 8;
 	data[7] = j1939->this_ecu_tp_cm.PGN_of_the_packeted_message >> 16;


### PR DESCRIPTION
Hi!
As a result of reading the code and applying it in practice, I found out that the response (TP.CM_CTS) and the request (TP.CM_RTS) to connect the transport protocol are the same. The remaining scripts and communication packets via the transport protocol did not have to be checked
![photo_2024-04-15_11-58-57](https://github.com/DanielMartensson/Open-SAE-J1939/assets/35974082/35308d63-b578-4d8f-9e7b-123043dea7e4)
