### PR TITLE
Creating a library in CMake that can be included in C++ projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(Open-SAE-J1939 C)
 
-FILE(GLOB_RECURSE SOURCE_FILES_LIST "Src/*.c" "Src/*.c")
+file(GLOB_RECURSE ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/*.c")
 
-add_executable(main ${SOURCE_FILES_LIST})
+set(MAIN_SRC "${CMAKE_CURRENT_SOURCE_DIR}/Src/Main.c")
+
+list(REMOVE_ITEM ALL_SOURCE_FILES ${MAIN_SRC})
+
+add_library(opensaej1939 STATIC ${ALL_SOURCE_FILES})
+
+target_include_directories(opensaej1939 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Src")
+
+add_executable(main ${MAIN_SRC})
+
+target_link_libraries(main PRIVATE opensaej1939)
+
+target_include_directories(main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/Src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,24 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(Open-SAE-J1939 C)
 
+# Default value if not set externally
+if(NOT DEFINED PROCESSOR_CHOICE)
+    set(PROCESSOR_CHOICE NO_PROCESSOR)
+endif()
+
+# Make processor choice a compile definition
+add_compile_definitions(PROCESSOR_CHOICE=${PROCESSOR_CHOICE})
+
+# Collect sources
 file(GLOB_RECURSE ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/*.c")
-
 set(MAIN_SRC "${CMAKE_CURRENT_SOURCE_DIR}/Src/Main.c")
-
 list(REMOVE_ITEM ALL_SOURCE_FILES ${MAIN_SRC})
 
+# Library
 add_library(opensaej1939 STATIC ${ALL_SOURCE_FILES})
-
 target_include_directories(opensaej1939 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/Src")
 
+# Executable
 add_executable(main ${MAIN_SRC})
-
 target_link_libraries(main PRIVATE opensaej1939)
-
 target_include_directories(main PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/Src")

--- a/Src/Hardware/Hardware.h
+++ b/Src/Hardware/Hardware.h
@@ -16,7 +16,9 @@
 #define AVR 4
 #define QT_USB 5
 #define INTERNAL_CALLBACK 6
+#ifndef PROCESSOR_CHOICE
 #define PROCESSOR_CHOICE NO_PROCESSOR
+#endif
 
 /* C Standard library */
 #include "../Open_SAE_J1939/C89_Library.h"

--- a/Src/Open_SAE_J1939/C89_Library.h
+++ b/Src/Open_SAE_J1939/C89_Library.h
@@ -44,6 +44,11 @@ typedef uint8_t bool;
 #define SAE_J1939_INLINE inline
 
 #endif
+
+#else
+
+#define SAE_J1939_INLINE inline
+
 #endif
 
 #endif /* OPEN_SAE_J1939_C89_LIBRARY_H_ */


### PR DESCRIPTION
Thank you for this project, and for making it public like this.

I wanted to use this J1939 stack in a C++ project and needed to introduce this change.
The CMakeLists.txt now creates a static library "libopensaej1939.a" and also keeps track of
the needed include paths. I needed also a fix for the SAE_J1939_INLINE flag, which did not 
compile in the c++ world (where __cplusplus is defined).

Now I can build a new C++ project, include this as a subproject and just do in CMakeLists.txt:

```
add_subdirectory(Open-SAE-J1939)
add_executable(j1939node src/j1939node.cpp)
target_link_libraries(j1939node PRIVATE opensaej1939)
```

This is an improvement that better suits my use case and I thought it might be interesting
for you  upstream as well.

With this PR, the "PROCESSOR_CHOICE" can be conditionally defined during cmake setup:

```
cmake .. -DPROCESSOR_CHOICE=[value]
```
