### PR TITLE
Adding support for SocketCAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(Open-SAE-J1939 C)
 
-# Default value if not set externally
+# Default value for PROCESSOR_CHOICE if not set externally
 if(NOT DEFINED PROCESSOR_CHOICE)
     set(PROCESSOR_CHOICE NO_PROCESSOR)
 endif()
@@ -15,7 +15,7 @@ file(GLOB_RECURSE ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/*.c")
 set(MAIN_SRC "${CMAKE_CURRENT_SOURCE_DIR}/Src/Main.c")
 list(REMOVE_ITEM ALL_SOURCE_FILES ${MAIN_SRC})
 
-# remove SocketCAN_Transmit_Receive.c if not SOCKETCAN
+# remove translation unit "SocketCAN_Transmit_Receive.c" if not SOCKETCAN
 if(NOT "${PROCESSOR_CHOICE}" STREQUAL "SOCKETCAN")
     list(REMOVE_ITEM ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/Hardware/SocketCAN_Transmit_Receive.c")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,18 @@ if(NOT DEFINED PROCESSOR_CHOICE)
     set(PROCESSOR_CHOICE NO_PROCESSOR)
 endif()
 
-# Make processor choice a compile definition
+# Make it a compile definition
 add_compile_definitions(PROCESSOR_CHOICE=${PROCESSOR_CHOICE})
 
 # Collect sources
 file(GLOB_RECURSE ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/*.c")
 set(MAIN_SRC "${CMAKE_CURRENT_SOURCE_DIR}/Src/Main.c")
 list(REMOVE_ITEM ALL_SOURCE_FILES ${MAIN_SRC})
+
+# remove SocketCAN_Transmit_Receive.c if not SOCKETCAN
+if(NOT "${PROCESSOR_CHOICE}" STREQUAL "SOCKETCAN")
+    list(REMOVE_ITEM ALL_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/Src/Hardware/SocketCAN_Transmit_Receive.c")
+endif()
 
 # Library
 add_library(opensaej1939 STATIC ${ALL_SOURCE_FILES})

--- a/Src/Hardware/CAN_Transmit_Receive.c
+++ b/Src/Hardware/CAN_Transmit_Receive.c
@@ -24,6 +24,8 @@ static void (*Callback_Function_Delay_ms)(uint8_t) = NULL;
 #include "CAN_to_USB/can_to_usb.h"
 #elif PROCESSOR_CHOICE == INTERNAL_CALLBACK
 /* Nothing here because else statement should not be running */
+#elif PROCESSOR_CHOICE == SOCKETCAN
+#include "SocketCAN.h"
 #else
 /* Internal fields */
 static bool internal_new_message[256] = { false };
@@ -92,6 +94,8 @@ ENUM_J1939_STATUS_CODES CAN_Send_Message(uint32_t ID, uint8_t data[]) {
 	/* Implement your CAN send 8 bytes message function for the AVR platform */
 #elif PROCESSOR_CHOICE == QT_USB
 	status = QT_USB_Transmit(ID, data, 8);
+#elif PROCESSOR_CHOICE == SOCKETCAN
+  status = socketcan_transmit(ID, data, 8);
 #elif PROCESSOR_CHOICE == INTERNAL_CALLBACK
 	/* Call our callback function */
 	Callback_Function_Send(ID, 8, data);
@@ -131,6 +135,8 @@ ENUM_J1939_STATUS_CODES CAN_Send_Request(uint32_t ID, uint8_t PGN[]) {
 	/* Implement your CAN send 3 bytes message function for the AVR platform */
 #elif PROCESSOR_CHOICE == QT_USB
 	status = QT_USB_Transmit(ID, PGN, 3);                       /* PGN is always 3 bytes */
+#elif PROCESSOR_CHOICE == SOCKETCAN
+  status = socketcan_transmit(ID, PGN, 3);
 #elif PROCESSOR_CHOICE == INTERNAL_CALLBACK
 	/* Call our callback function */
 	Callback_Function_Send(ID, 3, PGN);
@@ -161,6 +167,8 @@ bool CAN_Read_Message(uint32_t* ID, uint8_t data[]) {
 	/* Implement your CAN function to get ID, data[] and the flag is_new_message here for the AVR platform */
 #elif PROCESSOR_CHOICE == QT_USB
 	QT_USB_Get_ID_Data(ID, data, &is_new_message);
+#elif PROCESSOR_CHOICE == SOCKETCAN
+  socketcan_receive(ID, data, &is_new_message);
 #elif PROCESSOR_CHOICE == INTERNAL_CALLBACK
 	Callback_Function_Read(ID, data, &is_new_message);
 #else
@@ -200,6 +208,10 @@ void CAN_Delay(uint8_t milliseconds) {
 
 #elif PROCESSOR_CHOICE == INTERNAL_CALLBACK
 	Callback_Function_Delay_ms(milliseconds);
+
+#elif PROCESSOR_CHOICE == SOCKETCAN
+  #include <unistd.h>
+  usleep(milliseconds*1000);
 #else
 	/* Nothing */
 #endif

--- a/Src/Hardware/Hardware.h
+++ b/Src/Hardware/Hardware.h
@@ -16,6 +16,7 @@
 #define AVR 4
 #define QT_USB 5
 #define INTERNAL_CALLBACK 6
+#define SOCKETCAN 7
 #ifndef PROCESSOR_CHOICE
 #define PROCESSOR_CHOICE NO_PROCESSOR
 #endif

--- a/Src/Hardware/SocketCAN.h
+++ b/Src/Hardware/SocketCAN.h
@@ -1,0 +1,22 @@
+#ifndef OPENSAE_SOCKETCAN_H
+#define OPENSAE_SOCKETCAN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SOCKETCAN_IFNAME
+#define SOCKETCAN_IFNAME "can0"
+#endif
+
+#include <stdint.h>
+
+int socketcan_receive(uint32_t* ID, uint8_t data[], bool* is_new_message);
+int socketcan_transmit(uint32_t ID, uint8_t data[], uint8_t DLC);
+int socketcan_setup(const char *ifname);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Src/Hardware/SocketCAN_Transmit_Receive.c
+++ b/Src/Hardware/SocketCAN_Transmit_Receive.c
@@ -1,0 +1,136 @@
+/*
+ * SocketCAN_Transmit_Receive.c
+ *
+ *  Created on: 24 june 2025
+ *      Author: Rickard Hallerbäck
+ */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+
+#include "SocketCAN.h"
+
+// Global variables
+int can_socket = -1;
+bool can_initialized = false;
+
+// Function to initialize SocketCAN
+int socketcan_setup(const char *ifname) {
+    struct ifreq ifr;
+    struct sockaddr_can addr;
+
+    if (can_initialized) {
+        return 0; // Already initialized
+    }
+
+    // Create the socket
+    can_socket = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (can_socket < 0) {
+        perror("Error while opening CAN socket");
+        return -1;
+    }
+
+    // Disable reception of own messages
+    int disable_loopback = 0;
+    if (setsockopt(can_socket, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &disable_loopback, sizeof(disable_loopback)) < 0) {
+        perror("Error disabling loopback");
+        close(can_socket);
+        return -1;
+    }
+
+    // Specify the CAN interface
+    strcpy(ifr.ifr_name, ifname);
+    if (ioctl(can_socket, SIOCGIFINDEX, &ifr) < 0) {
+        fprintf(stderr, "Error getting interface index for '%s'", ifname);
+        close(can_socket);
+        can_socket = -1;
+        return -1;
+    }
+
+    // Bind the socket to the CAN interface
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    if (bind(can_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        fprintf(stderr, "Error binding CAN socket for '%s'", ifname);
+        close(can_socket);
+        can_socket = -1;
+        return -1;
+    }
+
+    can_initialized = true;
+    return 0;
+}
+
+bool socketcan_is_initialized() {
+  return can_initialized;
+}
+
+// Transmit a CAN message
+int socketcan_transmit(uint32_t ID, uint8_t data[], uint8_t DLC) {
+    if (!socketcan_is_initialized()) {
+      socketcan_setup(SOCKETCAN_IFNAME);
+    }
+
+    if (!can_initialized || can_socket < 0) {
+        return -1;
+    }
+
+    struct can_frame frame;
+    memset(&frame, 0, sizeof(frame));
+
+    frame.can_id = ID | CAN_EFF_FLAG;
+    frame.can_dlc = DLC;
+
+    memcpy(frame.data, data, DLC > 8 ? 8 : DLC);
+
+    int bytes_sent = write(can_socket, &frame, sizeof(struct can_frame));
+
+    return (bytes_sent == sizeof(frame)) ? 0 : -1;
+}
+
+// Receive a CAN message (non-blocking recommended)
+int socketcan_receive(uint32_t* ID, uint8_t data[], bool* is_new_message) {
+    if (!socketcan_is_initialized()) {
+        socketcan_setup(SOCKETCAN_IFNAME);
+    }
+
+    if (!can_initialized || can_socket < 0) {
+        *is_new_message = false;
+        return -1;
+    }
+
+    struct can_frame frame;
+    ssize_t bytes_read = read(can_socket, &frame, sizeof(struct can_frame));
+
+    if (bytes_read < (ssize_t)sizeof(struct can_frame)) {
+        *is_new_message = false;
+        return -1;
+    }
+
+    // Extract the ID, masking out flags
+    if (frame.can_id & CAN_EFF_FLAG) {
+        *ID = frame.can_id & CAN_EFF_MASK;  // 29-bit ID
+    } else {
+        *ID = frame.can_id & CAN_SFF_MASK;  // 11-bit ID
+    }
+
+    // Copy up to 8 bytes of data
+    uint8_t len = (frame.can_dlc <= 8) ? frame.can_dlc : 8;
+    memcpy(data, frame.data, len);
+
+    *is_new_message = true;
+    return 0;
+}


### PR DESCRIPTION
This project clearly targets an embedded environment, specifically an STM32 platform running FreeRTOS.
But I wanted to fire this up on a Linux machine so I built support for SocketCAN.
It only runs and builds on Linux systems so the main translation unit enabling this "SocketCAN_Transmit_Receive.c" is omitted if not "PROCESSOR_CHOICE" is set to "SOCKETCAN". Embedded Linux systems could also benefit from
this and I thought it was a worth while contribution.

To build with the SocketCAN option enabled, this will only build on Linux where one can take POSIX for granted, use the compile option "PROCESSOR_CHOICE" and set it to "SOCKETCAN" in the cmake command:

```
mkdir build
cmake -B build -DPROCESSOR_CHOICE=SOCKETCAN .
cmake --build build
```


Best regards, and thanks again for the effort
Rickard