### PR TITLE
Adding SAE_J1939 application layer callbacks

### DIFF
--- a/Src/Examples/Open SAE J1939/Application Layer callback.txt
+++ b/Src/Examples/Open SAE J1939/Application Layer callback.txt
@@ -1,0 +1,272 @@
+*
+ * Main.c
+ *
+ * The purpose of this file is to show how one can build
+ * applications using the SAE J1939 Application layer callback.
+ * This example program uses SOCKETCAN as a targeted platform
+ * and can act as both a sender and a receiver of data.
+ * If the --send argument is used, it will send requests
+ * for data to be retrieved from the other node.
+ *
+ *  Created on: 16 juli 2025
+ *      Author: Rickard Hallerbäck
+ */
+#include <cstring>
+#include <iostream>
+#include <stdio.h>
+#include <string>
+
+/* Include Open SAE J1939 */
+#include "Open_SAE_J1939/Open_SAE_J1939.h"
+
+/* Include ISO 11783 */
+#include "ISO_11783/ISO_11783-7_Application_Layer/Application_Layer.h"
+
+/* For using the SOCKETCAN backend */
+#include "Hardware/SocketCAN.h"
+
+constexpr int DEBUG_NONE = 0;
+constexpr int DEBUG_LOW = 1;
+constexpr int DEBUG_MEDIUM = 2;
+constexpr int DEBUG_HIGH = 3;
+
+typedef struct ECUArguments {
+  uint8_t this_ECU_address = 0x50;
+  uint32_t identity_number = 100;
+  std::string ifname = "vcan0"; // SOCKETCAN is used for this program
+  int debug = DEBUG_NONE;
+  bool send = false;
+} ECUArguments;
+
+ECUArguments args;
+
+/* J1939 stack */
+J1939 j1939 = {0};
+
+/* This function reads the CAN traffic */
+void Callback_Function_Traffic(uint32_t ID, uint8_t DLC, uint8_t data[],
+                               bool is_TX) {
+  if (args.debug > DEBUG_LOW) {
+    /* Print if it is TX or RX */
+    printf("%s\t", is_TX ? "TX" : "RX");
+
+    /* Print ID as hex */
+    printf("%08X\t", ID);
+
+    /* Print the data */
+    uint8_t i;
+    for (i = 0U; i < DLC; i++) {
+      printf("%X\t", data[i]);
+    }
+
+    /* Print the non-data */
+    for (i = DLC; i < 8U; i++) {
+      printf("%X\t", 0U);
+    }
+
+    /* New line */
+    printf("\n");
+  }
+}
+
+void printHelp(const char *programName) {
+  std::cout
+      << "Usage: " << programName << " [OPTIONS]\n\n"
+      << "Options:\n"
+      << "  -e, --ecu-address <hex/dec>     Set ECU address (default: 0x50)\n"
+      << "  -i, --identity-number <number>  Set ECU identity number (default: "
+         "100)\n"
+      << "  -c, --can-interface <string>    Set ifname of socketcan interface "
+         "(default: vcan0)\n"
+      << "  --debug <int>                   Set debug level (default 0 - no "
+         "debug)\n"
+      << "  -h, --help                      Show this help message\n";
+}
+
+void parseArguments(int argc, char *argv[]) {
+  for (int i = 1; i < argc; ++i) {
+    if ((strcmp(argv[i], "--ecu-address") == 0 || strcmp(argv[i], "-e") == 0) &&
+        i + 1 < argc) {
+      args.this_ECU_address =
+          static_cast<uint8_t>(strtoul(argv[++i], nullptr, 0));
+    } else if ((strcmp(argv[i], "--identity-number") == 0 ||
+                strcmp(argv[i], "-i") == 0) &&
+               i + 1 < argc) {
+      args.identity_number =
+          static_cast<uint32_t>(strtoul(argv[++i], nullptr, 0));
+    } else if (strcmp(argv[i], "--debug") == 0 && i + 1 < argc) {
+      args.debug = static_cast<int>(strtoul(argv[++i], nullptr, 0));
+    } else if ((strcmp(argv[i], "--can-interface") == 0 ||
+                strcmp(argv[i], "-c") == 0) &&
+               i + 1 < argc) {
+      args.ifname = argv[++i];
+    } else if (strcmp(argv[i], "--send") == 0) {
+      args.send = true;
+    } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+      printHelp(argv[0]);
+      std::exit(0);
+    } else {
+      std::cerr << "Unknown or malformed option: " << argv[i] << "\n";
+      printHelp(argv[0]);
+      std::exit(EXIT_FAILURE);
+    }
+  }
+}
+
+void handle_ecu_identification(ECU_identification *id) {
+  printf("--- Incoming ECU identification Message ---\n");
+  printf("    From ECU: %d\n", id->from_ecu_address);
+  printf("    Serial: %s\n", id->ecu_serial_number);
+  printf("    Part: %s\n", id->ecu_part_number);
+  printf("    Location: %s\n", id->ecu_location);
+  printf("    Type: %s\n", id->ecu_type);
+  printf("-------------------------------------------\n");
+}
+
+void handle_proprietary_b(Proprietary_B *msg) {
+  printf("--- Incoming Proprietary B Message ---\n");
+  printf("    From ECU: %d\n", msg->from_ecu_address);
+  printf("    PGN: %d\n", msg->pgn);
+  printf("    total bytes: %d\n", msg->total_bytes);
+  printf("    data: ");
+  int i = 0;
+  while (i < msg->total_bytes) {
+    printf("%c", msg->data[i]);
+    i++;
+  }
+  printf("\n");
+  printf("--------------------------------------\n");
+  SAE_J1939_Send_Request(&j1939, args.this_ECU_address + 1,
+                         PGN_ECU_IDENTIFICATION);
+}
+
+void handle_incoming(SAE_Application_Info msg) {
+  switch (msg.type) {
+  case PROPRIETARY_B: {
+    handle_proprietary_b(msg.proprietary_b);
+    break;
+  }
+  case IDENTIFICATION_ECU: {
+    handle_ecu_identification(msg.ecu_identification);
+    break;
+  }
+  default:
+    /* Handles for IDENTIFICATION_SOFTWARE, IDENTIFICATION_COMPONENT,
+     * PROPRIETARY_A can be added here likewise */
+    break;
+  }
+}
+
+void setupThisJ1939ECU() {
+  /* Create our J1939 structure */
+  j1939.information_this_ECU.this_ECU_address = args.this_ECU_address;
+  j1939.information_this_ECU.this_name.identity_number = args.identity_number;
+  j1939.information_this_ECU.this_name.manufacturer_code =
+      400; /* From 0 to 2047 */
+  j1939.information_this_ECU.this_name.function_instance =
+      20;                                                /* From 0 to 31 */
+  j1939.information_this_ECU.this_name.ECU_instance = 1; /* From 0 to 7 */
+  j1939.information_this_ECU.this_name.function =
+      FUNCTION_VDC_MODULE;                                  /* From 0 to 255 */
+  j1939.information_this_ECU.this_name.vehicle_system = 50; /* From 0 to 127 */
+  j1939.information_this_ECU.this_name.arbitrary_address_capable =
+      0; /* From 0 to 1 */
+  j1939.information_this_ECU.this_name.industry_group =
+      INDUSTRY_GROUP_GLOBAL; /* From 0 to 7 */
+  j1939.information_this_ECU.this_name.vehicle_system_instance = 10;
+
+  // Set the ECU length of each field to 6 as an example (can be max 30).
+  j1939.information_this_ECU.this_identifications.ecu_identification
+      .length_of_each_field = 6;
+  char ecu_part_number[] = "Part1";
+  char ecu_serial_number[] = "12345";
+  char ecu_location[] = "corner";
+  char ecu_type[] = "random";
+  memcpy(j1939.information_this_ECU.this_identifications.ecu_identification
+             .ecu_part_number,
+         ecu_part_number, 6);
+  memcpy(j1939.information_this_ECU.this_identifications.ecu_identification
+             .ecu_serial_number,
+         ecu_serial_number, 6);
+  memcpy(j1939.information_this_ECU.this_identifications.ecu_identification
+             .ecu_location,
+         ecu_location, 6);
+  memcpy(j1939.information_this_ECU.this_identifications.ecu_identification
+             .ecu_type,
+         ecu_type, 6);
+
+  uint8_t i;
+  for (i = 0; i < 255; i++) {
+    j1939.other_ECU_address[i] = 0xFF;
+  }
+
+  char content[] = "This is sent as a proprietary B message";
+  size_t message_size = strlen(content);
+
+  if (!args.send) {
+    j1939.this_proprietary.proprietary_B[0].pgn = 65280;
+    j1939.this_proprietary.proprietary_B[0].total_bytes = message_size;
+    memset(j1939.this_proprietary.proprietary_B[0].data, 0, MAX_PROPRIETARY_B);
+    memcpy(j1939.this_proprietary.proprietary_B[0].data, content,
+           sizeof(content));
+  } else {
+    j1939.from_other_ecu_proprietary.proprietary_B[0].pgn = 65280;
+    j1939.from_other_ecu_proprietary.proprietary_B[0].total_bytes =
+        message_size;
+  }
+  if (!args.send) {
+    printf("this_proprietary.Proprietary_B[0].pgn: %d [%d bytes] [WILL SEND "
+           "THIS]\n",
+           j1939.this_proprietary.proprietary_B[0].pgn,
+           j1939.this_proprietary.proprietary_B[0].total_bytes);
+  } else {
+    printf("from_other_ecu_proprietary.Proprietary_B[0].pgn: %d [%d bytes] "
+           "[WILL REQUEST THIS]\n",
+           j1939.from_other_ecu_proprietary.proprietary_B[0].pgn,
+           j1939.from_other_ecu_proprietary.proprietary_B[0].total_bytes);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  uint8_t other_ecu = 0xFE;
+
+  parseArguments(argc, argv);
+
+  // Setup socketcan
+  socketcan_setup(args.ifname.c_str());
+
+  // Setup this J1939 stack
+  setupThisJ1939ECU();
+
+  printf("This ECU address: %d\n", j1939.information_this_ECU.this_ECU_address);
+
+  /* This broadcast out this ECU NAME + address to all other ECU:s */
+  SAE_J1939_Response_Request_Address_Claimed(&j1939);
+
+  /* This asking all ECU about their NAME + address */
+  SAE_J1939_Send_Request_Address_Claimed(&j1939, 0xFF);
+
+  /* Callback for monitoring CAN activity */
+  CAN_Set_Callback_Functions(NULL, NULL, Callback_Function_Traffic, NULL);
+
+  /* Callback for handling SAE J1939 application layer */
+  SAE_J1939_Set_Application_Callback_Function(handle_incoming);
+
+  /* SAE J1939 process */
+  bool run = true;
+
+  if (args.send) {
+    SAE_J1939_Send_Request(&j1939, args.this_ECU_address + 1, 0xff00);
+  }
+
+  while (run) {
+    /* Read incoming messages */
+    Open_SAE_J1939_Listen_For_Messages(&j1939);
+  }
+
+  /* Save your ECU information */
+  Open_SAE_J1939_Closedown_ECU(&j1939);
+
+  return 0;
+}
+

--- a/Src/Open_SAE_J1939/Structs.h
+++ b/Src/Open_SAE_J1939/Structs.h
@@ -284,5 +284,25 @@ typedef struct {
 
 } J1939;
 
+/* Enum for SAE J1939 application information */
+typedef enum {
+  IDENTIFICATION_SOFTWARE,
+  IDENTIFICATION_ECU,
+  IDENTIFICATION_COMPONENT,
+  PROPRIETARY_A,
+  PROPRIETARY_B
+} SAE_Application_Info_Type;
+
+/* This struct is used to signal application information sent from another ECU over SAE J1939 */
+typedef struct{
+  SAE_Application_Info_Type type;
+  union {
+    struct Software_identification *software_identification;
+    struct ECU_identification *ecu_identification;
+    struct Component_identification *component_identification;
+    struct Proprietary_A *proprietary_a;
+    struct Proprietary_B *proprietary_b;
+  };
+} SAE_Application_Info;
 
 #endif /* OPEN_SAE_J1939_OPEN_SAE_J1939_STRUCTS_H_ */

--- a/Src/Open_SAE_J1939/Structs.h
+++ b/Src/Open_SAE_J1939/Structs.h
@@ -84,19 +84,19 @@ struct Name {
 };
 
 /* PGN: 0x00EF00 - Proprietary A where the data is manufacturer specific */
-struct Proprietary_A {
+typedef struct Proprietary_A {
 	uint16_t total_bytes;							/* Length of the data */
 	uint8_t data[MAX_PROPRIETARY_A];				/* This is the collected data */
 	uint8_t from_ecu_address;						/* From which ECU came this message */
-};
+} Proprietary_A;
 
 /* PGN: 0x00FF00 <-> 0x00FFFF - Proprietary B PGN range, where the data is manufacturer specific */
-struct Proprietary_B {
+typedef struct Proprietary_B {
 	uint32_t pgn;									/* The PGN that the ECU will be aware of, a value should be set to be able to send/receive this PGN */
 	uint16_t total_bytes;							/* Length of the data */
 	uint8_t data[MAX_PROPRIETARY_B];				/* This is the collected data */
 	uint8_t from_ecu_address;						/* From which ECU came this message */
-};
+} Proprietary_B;
 
 /* This struct holds manufacturer specific data */
 struct Proprietary {
@@ -153,31 +153,31 @@ struct DM {
 };
 
 /* PGN: 0x00FEDA - Storing the software identification from the reading process */
-struct Software_identification {
+typedef struct Software_identification {
 	uint8_t number_of_fields;						/* How many numbers contains in the identifications array */
 	uint8_t identifications[MAX_IDENTIFICATION];	/* This can be for example ASCII */
 	uint8_t from_ecu_address;						/* From which ECU came this message */
-};
+} Software_identification;
 
 /* PGN: 0x00FDC5 - Storing the ECU identification from the reading process */
-struct ECU_identification {
+typedef struct ECU_identification {
 	uint8_t length_of_each_field;					/* The real length of the fields - Not part of J1939 standard, only for the user */
 	uint8_t ecu_part_number[MAX_IDENTIFICATION];	/* ASCII field */
 	uint8_t ecu_serial_number[MAX_IDENTIFICATION];	/* ASCII field */
 	uint8_t ecu_location[MAX_IDENTIFICATION];		/* ASCII field */
 	uint8_t ecu_type[MAX_IDENTIFICATION];			/* ASCII field */
 	uint8_t from_ecu_address;						/* From which ECU came this message */
-};
+} ECU_identification;
 
 /* PGN: 0x00FEEB - Storing the component identification from the reading process */
-struct Component_identification {
+typedef struct Component_identification {
 	uint8_t length_of_each_field;					/* The real length of the fields - Not part of J1939 standard, only for the user  */
 	uint8_t component_product_date[MAX_IDENTIFICATION];	/* ASCII field */
 	uint8_t component_model_name[MAX_IDENTIFICATION];	/* ASCII field */
 	uint8_t component_serial_number[MAX_IDENTIFICATION];/* ASCII field */
 	uint8_t component_unit_name[MAX_IDENTIFICATION];	/* ASCII field */
 	uint8_t from_ecu_address;						/* From which ECU came this message */
-};
+} Component_identification;
 
 /* Storing the identifications from the reading process */
 struct Identifications {
@@ -234,7 +234,7 @@ struct Auxiliary_valve_measured_position {
 };
 
 /* This struct is used for save information and load information from hard drive/SD-card/flash etc. due to the large size of J1939 */
-typedef struct{
+typedef struct {
 	struct Name this_name;
 	uint8_t this_ECU_address;
 	struct Identifications this_identifications;
@@ -297,11 +297,11 @@ typedef enum {
 typedef struct{
   SAE_Application_Info_Type type;
   union {
-    struct Software_identification *software_identification;
-    struct ECU_identification *ecu_identification;
-    struct Component_identification *component_identification;
-    struct Proprietary_A *proprietary_a;
-    struct Proprietary_B *proprietary_b;
+    Software_identification *software_identification;
+    ECU_identification *ecu_identification;
+    Component_identification *component_identification;
+    Proprietary_A *proprietary_a;
+    Proprietary_B *proprietary_b;
   };
 } SAE_Application_Info;
 

--- a/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
+++ b/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
@@ -72,12 +72,16 @@ void SAE_J1939_Read_Transport_Protocol_Data_Transfer(J1939 *j1939, uint8_t SA, u
 	case PGN_SOFTWARE_IDENTIFICATION:
 		SAE_J1939_Read_Response_Request_Software_Identification(j1939, SA, complete_data);
 		break;
-	case PGN_ECU_IDENTIFICATION:
+	case PGN_ECU_IDENTIFICATION: { 
+		j1939->from_other_ecu_identifications.ecu_identification.length_of_each_field = total_message_size/4;
 		SAE_J1939_Read_Response_Request_ECU_Identification(j1939, SA, complete_data);
 		break;
-	case PGN_COMPONENT_IDENTIFICATION:
+  }
+	case PGN_COMPONENT_IDENTIFICATION: {
+		j1939->from_other_ecu_identifications.component_identification.length_of_each_field = total_message_size/4;
 		SAE_J1939_Read_Response_Request_Component_Identification(j1939, SA, complete_data);
 		break;
+  }
 	case PGN_PROPRIETARY_A:
 		SAE_J1939_Read_Response_Request_Proprietary_A(j1939, SA, complete_data);
 		break;

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
@@ -5,24 +5,12 @@ extern "C" {
 #include "Application_Layer.h"
 
 /* Callback functions */
-void (*Callback_Function_Software_Identification)(struct Software_identification *) = 0;
-void (*Callback_Function_ECU_Identification)(struct ECU_identification *) = 0;
-void (*Callback_Function_Component_Identification)(struct Component_identification *) = 0;
-void (*Callback_Function_Proprietary_A)(struct Proprietary_A *) = 0;
-void (*Callback_Function_Proprietary_B)(struct Proprietary_B *) = 0;
+void (*Callback_Function_Application)(SAE_Application_Info) = 0;
 
-void SAE_J1939_Set_Callback_Functions(
-    void (*Callback_Function_Software_Identification_)(struct Software_identification *),
-    void (*Callback_Function_ECU_Identification_)(struct ECU_identification *),
-    void (*Callback_Function_Component_Identification_)(struct Component_identification *),
-    void (*Callback_Function_Proprietary_A_)(struct Proprietary_A *),
-    void (*Callback_Function_Proprietary_B_)(struct Proprietary_B *)
+void SAE_J1939_Set_Application_Callback_Function(
+    void (*Callback_Function)(SAE_Application_Info)
 ) {
-    Callback_Function_Software_Identification = Callback_Function_Software_Identification_;
-    Callback_Function_ECU_Identification = Callback_Function_ECU_Identification_;
-    Callback_Function_Component_Identification = Callback_Function_Component_Identification_;
-    Callback_Function_Proprietary_A = Callback_Function_Proprietary_A_;
-    Callback_Function_Proprietary_B = Callback_Function_Proprietary_B_;
+    Callback_Function_Application = Callback_Function;
 }
 
 #ifdef __cplusplus

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
@@ -1,0 +1,31 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "Application_Layer.h"
+
+/* Callback functions */
+void (*Callback_Function_Software_Identification)(struct Software_identification *) = 0;
+void (*Callback_Function_ECU_Identification)(struct ECU_identification *) = 0;
+void (*Callback_Function_Component_Identification)(struct Component_identification *) = 0;
+void (*Callback_Function_Proprietary_A)(struct Proprietary_A *) = 0;
+void (*Callback_Function_Proprietary_B)(struct Proprietary_B *) = 0;
+
+void SAE_J1939_Set_Callback_Functions(
+    void (*Callback_Function_Software_Identification_)(struct Software_identification *),
+    void (*Callback_Function_ECU_Identification_)(struct ECU_identification *),
+    void (*Callback_Function_Component_Identification_)(struct Component_identification *),
+    void (*Callback_Function_Proprietary_A_)(struct Proprietary_A *),
+    void (*Callback_Function_Proprietary_B_)(struct Proprietary_B *)
+) {
+    Callback_Function_Software_Identification = Callback_Function_Software_Identification_;
+    Callback_Function_ECU_Identification = Callback_Function_ECU_Identification_;
+    Callback_Function_Component_Identification = Callback_Function_Component_Identification_;
+    Callback_Function_Proprietary_A = Callback_Function_Proprietary_A_;
+    Callback_Function_Proprietary_B = Callback_Function_Proprietary_B_;
+}
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.c
@@ -5,7 +5,7 @@ extern "C" {
 #include "Application_Layer.h"
 
 /* Callback functions */
-void (*Callback_Function_Application)(SAE_Application_Info) = 0;
+void (*Callback_Function_Application)(SAE_Application_Info) = NULL;
 
 void SAE_J1939_Set_Application_Callback_Function(
     void (*Callback_Function)(SAE_Application_Info)

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.h
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.h
@@ -22,14 +22,10 @@
 extern "C" {
 #endif
 
-extern void (*Callback_Function_Software_Identification)(struct Software_identification *);
-extern void (*Callback_Function_ECU_Identification)(struct ECU_identification *);
-extern void (*Callback_Function_Component_Identification)(struct Component_identification *);
-extern void (*Callback_Function_Proprietary_A)(struct Proprietary_A *);
-extern void (*Callback_Function_Proprietary_B)(struct Proprietary_B *);
+extern void (*Callback_Function_Application)(SAE_Application_Info);
 
 /* Callback functions */
-void SAE_J1939_Set_Callback_Functions(void (*Callback_Function_Software_Identification_)(struct Software_identification *), void (*Callback_Function_ECU_Identification_)(struct ECU_identification *), void (*Callback_Function_Component_Identification)(struct Component_identification *), void (*Callback_Function_Proprietary_A_)(struct Proprietary_A *), void (*Callback_Function_Proprietary_B_)(struct Proprietary_B *));
+void SAE_J1939_Set_Application_Callback_Function(void (*Callback_Function_Application_)(SAE_Application_Info));
 
 /* Software identification */
 ENUM_J1939_STATUS_CODES SAE_J1939_Send_Request_Software_Identification(J1939 *j1939, uint8_t DA);

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.h
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Application_Layer.h
@@ -22,6 +22,15 @@
 extern "C" {
 #endif
 
+extern void (*Callback_Function_Software_Identification)(struct Software_identification *);
+extern void (*Callback_Function_ECU_Identification)(struct ECU_identification *);
+extern void (*Callback_Function_Component_Identification)(struct Component_identification *);
+extern void (*Callback_Function_Proprietary_A)(struct Proprietary_A *);
+extern void (*Callback_Function_Proprietary_B)(struct Proprietary_B *);
+
+/* Callback functions */
+void SAE_J1939_Set_Callback_Functions(void (*Callback_Function_Software_Identification_)(struct Software_identification *), void (*Callback_Function_ECU_Identification_)(struct ECU_identification *), void (*Callback_Function_Component_Identification)(struct Component_identification *), void (*Callback_Function_Proprietary_A_)(struct Proprietary_A *), void (*Callback_Function_Proprietary_B_)(struct Proprietary_B *));
+
 /* Software identification */
 ENUM_J1939_STATUS_CODES SAE_J1939_Send_Request_Software_Identification(J1939 *j1939, uint8_t DA);
 ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_Software_Identification(J1939* j1939, uint8_t DA);

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Component_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Component_Identification.c
@@ -83,5 +83,8 @@ void SAE_J1939_Read_Response_Request_Component_Identification(J1939 *j1939, uint
 		j1939->from_other_ecu_identifications.component_identification.component_unit_name[i] = data[i + length_of_each_field*3];
 	}
 	j1939->from_other_ecu_identifications.component_identification.from_ecu_address = SA;
+  if (Callback_Function_Component_Identification) {
+    Callback_Function_Component_Identification(&j1939->from_other_ecu_identifications.component_identification);
+  }
 }
 

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Component_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Component_Identification.c
@@ -83,8 +83,11 @@ void SAE_J1939_Read_Response_Request_Component_Identification(J1939 *j1939, uint
 		j1939->from_other_ecu_identifications.component_identification.component_unit_name[i] = data[i + length_of_each_field*3];
 	}
 	j1939->from_other_ecu_identifications.component_identification.from_ecu_address = SA;
-  if (Callback_Function_Component_Identification) {
-    Callback_Function_Component_Identification(&j1939->from_other_ecu_identifications.component_identification);
+  if (Callback_Function_Application) {
+    SAE_Application_Info info;
+    info.type = IDENTIFICATION_COMPONENT;
+    info.component_identification = &j1939->from_other_ecu_identifications.component_identification;
+    Callback_Function_Application(info);
   }
 }
 

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
@@ -86,7 +86,7 @@ void SAE_J1939_Read_Response_Request_ECU_Identification(J1939 *j1939, uint8_t SA
   if (Callback_Function_Application) {
     SAE_Application_Info info;
     info.type = IDENTIFICATION_ECU;
-    info.component_identification = &j1939->from_other_ecu_identifications.ecu_identification;
+    info.ecu_identification = &j1939->from_other_ecu_identifications.ecu_identification;
     Callback_Function_Application(info);
   }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
@@ -83,4 +83,7 @@ void SAE_J1939_Read_Response_Request_ECU_Identification(J1939 *j1939, uint8_t SA
 		j1939->from_other_ecu_identifications.ecu_identification.ecu_type[i] = data[i + length_of_each_field*3];
 	}
 	j1939->from_other_ecu_identifications.ecu_identification.from_ecu_address = SA;
+  if (Callback_Function_ECU_Identification) {
+    Callback_Function_ECU_Identification(&j1939->from_other_ecu_identifications.ecu_identification);
+  }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_ECU_Identification.c
@@ -83,7 +83,10 @@ void SAE_J1939_Read_Response_Request_ECU_Identification(J1939 *j1939, uint8_t SA
 		j1939->from_other_ecu_identifications.ecu_identification.ecu_type[i] = data[i + length_of_each_field*3];
 	}
 	j1939->from_other_ecu_identifications.ecu_identification.from_ecu_address = SA;
-  if (Callback_Function_ECU_Identification) {
-    Callback_Function_ECU_Identification(&j1939->from_other_ecu_identifications.ecu_identification);
+  if (Callback_Function_Application) {
+    SAE_Application_Info info;
+    info.type = IDENTIFICATION_ECU;
+    info.component_identification = &j1939->from_other_ecu_identifications.ecu_identification;
+    Callback_Function_Application(info);
   }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary.c
@@ -65,4 +65,7 @@ void SAE_J1939_Read_Response_Request_Proprietary_A(J1939* j1939, uint8_t SA, uin
 	uint16_t total_bytes = j1939->from_other_ecu_proprietary.proprietary_A.total_bytes;
 	memcpy(j1939->from_other_ecu_proprietary.proprietary_A.data, data, total_bytes);
 	j1939->from_other_ecu_proprietary.proprietary_A.from_ecu_address = SA;
+  if (Callback_Function_Proprietary_A) {
+    Callback_Function_Proprietary_A(&j1939->from_other_ecu_proprietary.proprietary_A);
+  }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary.c
@@ -65,7 +65,10 @@ void SAE_J1939_Read_Response_Request_Proprietary_A(J1939* j1939, uint8_t SA, uin
 	uint16_t total_bytes = j1939->from_other_ecu_proprietary.proprietary_A.total_bytes;
 	memcpy(j1939->from_other_ecu_proprietary.proprietary_A.data, data, total_bytes);
 	j1939->from_other_ecu_proprietary.proprietary_A.from_ecu_address = SA;
-  if (Callback_Function_Proprietary_A) {
-    Callback_Function_Proprietary_A(&j1939->from_other_ecu_proprietary.proprietary_A);
+  if (Callback_Function_Application) {
+    SAE_Application_Info info;
+    info.type = PROPRIETARY_A;
+    info.proprietary_a = &j1939->from_other_ecu_proprietary.proprietary_A;
+    Callback_Function_Application(info);
   }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
@@ -92,7 +92,10 @@ void SAE_J1939_Read_Response_Request_Proprietary_B(J1939* j1939, uint8_t SA, uin
 	uint16_t total_bytes = proprietary_B->total_bytes;
 	memcpy(proprietary_B->data, data, total_bytes);
 	proprietary_B->from_ecu_address = SA;
-  if (Callback_Function_Proprietary_B) {
-    Callback_Function_Proprietary_B(proprietary_B);
+  if (Callback_Function_Application) {
+    SAE_Application_Info info;
+    info.type = PROPRIETARY_B;
+    info.proprietary_b = proprietary_B;
+    Callback_Function_Application(info);
   }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
@@ -11,9 +11,6 @@
 #include "../SAE_J1939-21_Transport_Layer/Transport_Layer.h"
 #include "../../Hardware/Hardware.h"
 
-/* This is a call back function e.g listener, that will be called once SAE J1939 data is going to be sent */
-static void (*Callback_Function_Proprietary_B_)(uint32_t, uint8_t[]) = NULL;
-
 /*
  * Request Proprietary B to another ECU
  * PGN: 0x00FF00 <-> 0x00FFFF

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Proprietary_B.c
@@ -11,6 +11,9 @@
 #include "../SAE_J1939-21_Transport_Layer/Transport_Layer.h"
 #include "../../Hardware/Hardware.h"
 
+/* This is a call back function e.g listener, that will be called once SAE J1939 data is going to be sent */
+static void (*Callback_Function_Proprietary_B_)(uint32_t, uint8_t[]) = NULL;
+
 /*
  * Request Proprietary B to another ECU
  * PGN: 0x00FF00 <-> 0x00FFFF
@@ -92,4 +95,7 @@ void SAE_J1939_Read_Response_Request_Proprietary_B(J1939* j1939, uint8_t SA, uin
 	uint16_t total_bytes = proprietary_B->total_bytes;
 	memcpy(proprietary_B->data, data, total_bytes);
 	proprietary_B->from_ecu_address = SA;
+  if (Callback_Function_Proprietary_B) {
+    Callback_Function_Proprietary_B(proprietary_B);
+  }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Software_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Software_Identification.c
@@ -69,7 +69,10 @@ void SAE_J1939_Read_Response_Request_Software_Identification(J1939 *j1939, uint8
 	for(i = 0; i < data[0]; i++){
 		j1939->from_other_ecu_identifications.software_identification.identifications[i] = data[i+1];	 /* 1 for the number of fields */
 	}
-  if (Callback_Function_Software_Identification) {
-    Callback_Function_Software_Identification(&j1939->from_other_ecu_identifications.software_identification);
+  if (Callback_Function_Application) {
+    SAE_Application_Info info;
+    info.type = IDENTIFICATION_SOFTWARE;
+    info.software_identification = &j1939->from_other_ecu_identifications.software_identification;
+    Callback_Function_Application(info);
   }
 }

--- a/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Software_Identification.c
+++ b/Src/SAE_J1939/SAE_J1939-71_Application_Layer/Request_Software_Identification.c
@@ -69,4 +69,7 @@ void SAE_J1939_Read_Response_Request_Software_Identification(J1939 *j1939, uint8
 	for(i = 0; i < data[0]; i++){
 		j1939->from_other_ecu_identifications.software_identification.identifications[i] = data[i+1];	 /* 1 for the number of fields */
 	}
+  if (Callback_Function_Software_Identification) {
+    Callback_Function_Software_Identification(&j1939->from_other_ecu_identifications.software_identification);
+  }
 }


### PR DESCRIPTION
Hi Daniel,

I wanted these callbacks for convenience sake when working
with your stack. I think they are a good addition to the library.

The reason was that I wanted to request and listen for large messages,
divided in multiple packages. And I could not find a convenient way
with the CAN_Set_Callbacks_Functions .

Now one can do like this:

```C
void handle_proprietary_b(struct Proprietary_B *msg) {
  printf("--- Incoming Proprietary B Message ---\n");
  printf("    PGN: %d\n", msg->pgn);
  printf("    total bytes: %d\n", msg->total_bytes);
  printf("    data: ");
  int i = 0;
  while ( i < msg->total_bytes ) {
    printf("%c", msg->data[i]);
    i++;
  }
  printf("\n");
  printf("--------------------------------------\n");
}

int main() { 
   ....
  /* Callback for Proprietary_B messages */
  SAE_J1939_Set_Callback_Functions(NULL, NULL, NULL, NULL, handle_proprietary_b);
  ...
}
``` 

And it will be triggered when these data transfers are completed. 