### PR TITLE
Changing SocketCAN timeout from seconds to milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ That's the debugging mode for internal CAN feedback.
 This project can be built with CMake. The build can be configured to target different hardware platforms.
 Per default, no specific hardware platform is selected and all CAN messages are sent and received locally
 over an internal memory bus. However, if you want to send messages on a specific platform, you can set the
-'OPENSAE_J1939_TARGET_PLATFORM' compile definition during build. Here is an example of how to build the project using
+`OPENSAE_J1939_TARGET_PLATFORM` compile definition during build. Here is an example of how to build the project using
 SOCKETCAN as a targeted platform.
 
 ```bash
@@ -115,7 +115,7 @@ As an example, this command would set up your project to use the SocketCAN backe
 as well as setting the maximum number of distinct Proprietary B PGNs to 124 for your project.
 
 ```bash
-cmake -B build -DOPENSAE_J1939_TARGET_PLATFORM=SOCKETCAN -DMAX_PROPRIETARY_B_PGNS=124.
+cmake -B build -DOPENSAE_J1939_TARGET_PLATFORM=SOCKETCAN -DMAX_PROPRIETARY_B_PGNS=124 .
 ```
 
 # How to use the project

--- a/Src/Hardware/SocketCAN.h
+++ b/Src/Hardware/SocketCAN.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 #ifndef SOCKETCAN_RCVTIMEOUT
-/* Set the read timeout of the bus in seconds, 0 means no timeout and it will block on read operations */
+/* Set the read timeout of the bus in milliseconds, 0 means no timeout and it will block on read operations */
 #define SOCKETCAN_RCVTIMEOUT 1
 #endif
 

--- a/Src/Hardware/SocketCAN_Transmit_Receive.c
+++ b/Src/Hardware/SocketCAN_Transmit_Receive.c
@@ -30,7 +30,8 @@ bool can_initialized = false;
 int socketcan_setup(const char *ifname) {
   struct ifreq ifr;
   struct sockaddr_can addr;
-  struct timeval tv = {.tv_sec = SOCKETCAN_RCVTIMEOUT, .tv_usec = 0};
+  struct timeval tv = {.tv_sec = SOCKETCAN_RCVTIMEOUT / 1000,
+                       .tv_usec = (SOCKETCAN_RCVTIMEOUT % 1000) * 1000};
 
   if (can_initialized) {
     return 0; // Already initialized


### PR DESCRIPTION
Hej igen!

Ändrar så det är millisekunder och inte hela sekunder som gäller med timeouten..
Känns mer rimligt.. 

Passade även på att fixa ett småfel i READMEn. 