### PR TITLE
Fix DM1/DM2 TP handling and broadcast BAM flow

### DIFF
--- a/Src/Open_SAE_J1939/Listen_For_Messages.c
+++ b/Src/Open_SAE_J1939/Listen_For_Messages.c
@@ -59,10 +59,10 @@ ENUM_J1939_RX_MSG Open_SAE_J1939_Listen_For_Messages(J1939* j1939) {
 			rx_msg = RX_MSG_DM16;
 
 		/* Read Transport Protocol information from other ECU */
-		}else if(id0 == 0x1C && id1 == 0xEC && (DA == j1939->information_this_ECU.this_ECU_address || DA == 0xFF)){
+		}else if((id0 == 0x1C || id0 == 0x18) && id1 == 0xEC && (DA == j1939->information_this_ECU.this_ECU_address || DA == 0xFF)){
 			SAE_J1939_Read_Transport_Protocol_Connection_Management(j1939, SA, data);
 			rx_msg = RX_MSG_TP_CONN_MANAGEMENT;
-		}else if (id0 == 0x1C && id1 == 0xEB && (DA == j1939->information_this_ECU.this_ECU_address || DA == 0xFF)){
+		}else if ((id0 == 0x1C || id0 == 0x18) && id1 == 0xEB && (DA == j1939->information_this_ECU.this_ECU_address || DA == 0xFF)){
 			SAE_J1939_Read_Transport_Protocol_Data_Transfer(j1939, SA, data);
 			rx_msg = RX_MSG_TP_CONN_DATA_TRANSFER;
 

--- a/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Request.c
+++ b/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Request.c
@@ -17,164 +17,111 @@
  * Read a PGN request from another ECU about PGN information at this ECU. All listed PGN should be here
  * PGN: 0x00EA00 (59904)
  */
-void SAE_J1939_Read_Request(J1939 *j1939, uint8_t SA, uint8_t data[]) {
-	uint32_t PGN = (data[2] << 16) | (data[1] << 8) | data[0];
-	switch (PGN) {
-	case PGN_ACKNOWLEDGEMENT:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_ADDRESS_CLAIMED:
-		SAE_J1939_Response_Request_Address_Claimed(j1939);
-		break;
-	case PGN_COMMANDED_ADDRESS:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_ADDRESS_DELETE:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN); /* Not SAE J1939 standard */
-		break;
-	case PGN_DM1:
-		SAE_J1939_Response_Request_DM1(j1939, SA);
-		break;
-	case PGN_DM2:
-		SAE_J1939_Response_Request_DM2(j1939, SA);
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_DM3:
-		SAE_J1939_Response_Request_DM3(j1939, SA);
-		break;
-	case PGN_REQUEST:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_TP_CM:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_TP_DT:
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED, GROUP_FUNCTION_VALUE_NORMAL, PGN);
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_0:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_1:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_2:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_3:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_4:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_5:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_6:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_7:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_8:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_9:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_10:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_11:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_12:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_13:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_14:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_15:
-		ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_GENERAL_PURPOSE_VALVE_ESTIMATED_FLOW:
-		ISO_11783_Response_Request_General_Purpose_Valve_Estimated_Flow(j1939, SA);
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_0:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_1:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_2:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_3:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_4:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_5:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_6:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_7:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_8:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_9:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_10:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_11:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_12:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_13:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_14:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_AUXILIARY_VALVE_MEASURED_POSITION_15:
-		ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xF); /* PGN & 0xF = valve_number */
-		break;
-	case PGN_SOFTWARE_IDENTIFICATION:
-		SAE_J1939_Response_Request_Software_Identification(j1939, SA);
-		break;
-	case PGN_ECU_IDENTIFICATION:
-		SAE_J1939_Response_Request_ECU_Identification(j1939, SA);
-		break;
-	case PGN_COMPONENT_IDENTIFICATION:
-		SAE_J1939_Response_Request_Component_Identification(j1939, SA);
-		break;
-	case PGN_PROPRIETARY_A:
-		SAE_J1939_Response_Request_Proprietary_A(j1939, SA);
-		break;
-		/* Add more else if statements here for more read request */
-	default:
-		// Check if PGN is in the Proprietary B PGN range
-		if (((PGN >= PGN_PROPRIETARY_B_START) && (PGN <= PGN_PROPRIETARY_B_END)) ||
-			((PGN >= PGN_PROPRIETARY_B2_START) && (PGN <= PGN_PROPRIETARY_B2_END)))
-		{
-			bool is_supported = false;
-			SAE_J1939_Response_Request_Proprietary_B(j1939, SA, PGN, &is_supported);
-			if (is_supported) break; // Do not send PGN NOT supported ACK frame
-		}
-		SAE_J1939_Send_Acknowledgement(j1939, SA, CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_NOT_SUPPORTED, GROUP_FUNCTION_VALUE_NO_CAUSE, PGN);
-		break;
-	}
+void SAE_J1939_Read_Request(J1939* j1939, uint8_t SA, uint8_t data[])
+{
+    uint32_t PGN = ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | data[0];
+
+    // Determine response DA for the existing DM request cases:
+    //   - Broadcast request (DA=0xFF) → respond broadcast (BAM)
+    //   - Unicast request              → respond to the requester (SA)
+    uint8_t request_da     = (uint8_t)((j1939->ID >> 8) & 0xFFU);
+    uint8_t dm_response_da = (request_da == 0xFFU) ? 0xFFU : SA;
+
+    switch (PGN)
+    {
+        case PGN_ADDRESS_CLAIMED: SAE_J1939_Response_Request_Address_Claimed(j1939); break;
+        case PGN_ACKNOWLEDGEMENT:
+        case PGN_COMMANDED_ADDRESS:
+        case PGN_ADDRESS_DELETE:
+        case PGN_REQUEST:
+        case PGN_TP_CM:
+        case PGN_TP_DT:
+            SAE_J1939_Send_Acknowledgement(
+                j1939,
+                SA,
+                CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED,
+                GROUP_FUNCTION_VALUE_NORMAL,
+                PGN);
+            break;
+        case PGN_DM1: SAE_J1939_Response_Request_DM1(j1939, dm_response_da); break;
+        case PGN_DM2:
+            SAE_J1939_Response_Request_DM2(j1939, dm_response_da);
+            SAE_J1939_Send_Acknowledgement(
+                j1939,
+                SA,
+                CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_SUPPORTED,
+                GROUP_FUNCTION_VALUE_NORMAL,
+                PGN);
+            break;
+        case PGN_DM3: SAE_J1939_Response_Request_DM3(j1939, SA); break;
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_0:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_1:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_2:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_3:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_4:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_5:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_6:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_7:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_8:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_9:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_10:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_11:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_12:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_13:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_14:
+        case PGN_AUXILIARY_VALVE_ESTIMATED_FLOW_15:
+            ISO_11783_Response_Request_Auxiliary_Valve_Estimated_Flow(j1939, PGN & 0xFUL);
+            break;
+        case PGN_GENERAL_PURPOSE_VALVE_ESTIMATED_FLOW:
+            ISO_11783_Response_Request_General_Purpose_Valve_Estimated_Flow(j1939, SA);
+            break;
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_0:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_1:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_2:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_3:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_4:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_5:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_6:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_7:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_8:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_9:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_10:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_11:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_12:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_13:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_14:
+        case PGN_AUXILIARY_VALVE_MEASURED_POSITION_15:
+            ISO_11783_Response_Request_Auxiliary_Valve_Measured_Position(j1939, PGN & 0xFUL);
+            break;
+        case PGN_SOFTWARE_IDENTIFICATION:
+            SAE_J1939_Response_Request_Software_Identification(j1939, SA);
+            break;
+        case PGN_ECU_IDENTIFICATION:
+            SAE_J1939_Response_Request_ECU_Identification(j1939, SA);
+            break;
+        case PGN_COMPONENT_IDENTIFICATION:
+            SAE_J1939_Response_Request_Component_Identification(j1939, SA);
+            break;
+        case PGN_PROPRIETARY_A: SAE_J1939_Response_Request_Proprietary_A(j1939, SA); break;
+        default:
+            if (((PGN >= PGN_PROPRIETARY_B_START) && (PGN <= PGN_PROPRIETARY_B_END))
+                || ((PGN >= PGN_PROPRIETARY_B2_START) && (PGN <= PGN_PROPRIETARY_B2_END)))
+            {
+                bool is_supported = false;
+                SAE_J1939_Response_Request_Proprietary_B(j1939, SA, PGN, &is_supported);
+                if (is_supported)
+                {
+                    break;
+                }
+            }
+            SAE_J1939_Send_Acknowledgement(
+                j1939,
+                SA,
+                CONTROL_BYTE_ACKNOWLEDGEMENT_PGN_NOT_SUPPORTED,
+                GROUP_FUNCTION_VALUE_NO_CAUSE,
+                PGN);
+            break;
+    }
 }
 
 /*
@@ -183,9 +130,11 @@ void SAE_J1939_Read_Request(J1939 *j1939, uint8_t SA, uint8_t data[]) {
  */
 ENUM_J1939_STATUS_CODES SAE_J1939_Send_Request(J1939 *j1939, uint8_t DA, uint32_t PGN_code) {
 	uint8_t PGN[3];
-	PGN[0] = PGN_code;														/* PGN least significant bit */
-	PGN[1] = PGN_code >> 8;													/* PGN mid bit */
-	PGN[2] = PGN_code >> 16;												/* PGN most significant bit */
-	uint32_t ID = (0x18EA << 16) | (DA << 8) | j1939->information_this_ECU.this_ECU_address;
-	return CAN_Send_Request(ID, PGN);
+    PGN[0] = (uint8_t)(PGN_code);                 /* PGN least significant bit */
+    PGN[1] = (uint8_t)(PGN_code >> 8);            /* PGN mid bit */
+    PGN[2] = (uint8_t)(PGN_code >> 16);           /* PGN most significant bit */
+
+    uint32_t ID = (0x18EAUL << 16) | ((uint32_t)(DA) << 8)
+                  | (uint32_t)(j1939->information_this_ECU.this_ECU_address);
+    return CAN_Send_Request(ID, PGN);
 }

--- a/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
+++ b/Src/SAE_J1939/SAE_J1939-21_Transport_Layer/Transport_Protocol_Data_Transfer.c
@@ -130,21 +130,31 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Send_Transport_Protocol_Data_Transfer(J1939 *j
 		}
 		break;
 	case CONTROL_BYTE_TP_CM_CTS:
-		package[0] = j1939->from_other_ecu_tp_cm.next_packet_number_transmitted;				/* Next number of package */
-		bytes_sent = (j1939->from_other_ecu_tp_cm.next_packet_number_transmitted -1) * 7;
-		for (j = 0; j < 7; j++) {
-			if (bytes_sent < j1939->this_ecu_tp_cm.total_message_size_being_transmitted) {
-				package[j + 1] = j1939->this_ecu_tp_dt.data[bytes_sent++];						/* Data that we have collected */
+		bytes_sent = (j1939->from_other_ecu_tp_cm.next_packet_number_transmitted - 1U) * 7U;
+		for (i = 0; i < j1939->from_other_ecu_tp_cm.number_of_packets_to_be_transmitted; i++) {
+			uint8_t sequence_number = j1939->from_other_ecu_tp_cm.next_packet_number_transmitted + i;
+			if (sequence_number > j1939->this_ecu_tp_cm.number_of_packages_being_transmitted) {
+				break;
 			}
-			else {
-				package[j + 1] = 0xFF; 															/* Reserved */
+
+			package[0] = sequence_number;											/* Next number of package */
+			for (j = 0; j < 7; j++) {
+				if (bytes_sent < j1939->this_ecu_tp_cm.total_message_size_being_transmitted) {
+					package[j + 1] = j1939->this_ecu_tp_dt.data[bytes_sent++];				/* Data that we have collected */
+				}
+				else {
+					package[j + 1] = 0xFF;										/* Reserved */
+				}
+			}
+
+			/* Transmitt message */
+			status = CAN_Send_Message(ID, package);
+			if (status != STATUS_SEND_OK) {
+				break;
 			}
 		}
-
-		/* Transmitt message */
-		status = CAN_Send_Message(ID, package);
 		break;
 	}
-	
+
 	return status;
 }

--- a/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM1.c
+++ b/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM1.c
@@ -46,7 +46,7 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM1(J1939* j1939, uint8_t DA)
 		j1939->this_ecu_tp_dt.data[1] = (j1939->this_dm.dm1.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm1.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm1.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm1.SAE_flash_lamp_protect_lamp);
 		/* Load DTCs into TP data package */
 		uint8_t i;
-		for (i = 0; i < j1939->this_ecu_tp_cm.total_message_size_being_transmitted; i++){
+		for (i = 0; i < j1939->this_dm.errors_dm1_active; i++){
 			j1939->this_ecu_tp_dt.data[i*4 + 2] = j1939->this_dm.dm1.SPN[i];
 			j1939->this_ecu_tp_dt.data[i*4 + 3] = j1939->this_dm.dm1.SPN[i] >> 8;
 			j1939->this_ecu_tp_dt.data[i*4 + 4] = ((j1939->this_dm.dm1.SPN[i] >> 11) & 0b11100000) | j1939->this_dm.dm1.FMI[i];
@@ -100,7 +100,7 @@ void SAE_J1939_Read_Response_Request_DM1(J1939 *j1939, uint8_t SA, uint8_t data[
 		j1939->from_other_ecu_dm.dm1.from_ecu_address[i] = SA;
 	}
 
-	/* Check if we have no fault cause 
+	/* Check if we have no fault cause
 	 * When there is a single DM1 code, and the SPN is 0, this signals all DM1 messages have cleared and no active messages are left */
 	if (errors_dm1_active == 1 && j1939->from_other_ecu_dm.dm1.SPN[0] == 0) {
 		j1939->from_other_ecu_dm.errors_dm1_active = 0;

--- a/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM2.c
+++ b/Src/SAE_J1939/SAE_J1939-73_Diagnostics_Layer/DM2.c
@@ -39,17 +39,14 @@ ENUM_J1939_STATUS_CODES SAE_J1939_Response_Request_DM2(J1939 *j1939, uint8_t DA)
 	} else {
 		/* Multiple messages - Load data */
 		j1939->this_ecu_tp_cm.total_message_size_being_transmitted = (j1939->this_dm.errors_dm2_active *4) +2 ;				/* set total message size where each DTC is 4 btyes, plus 2 bytes for the lamp code */
-		j1939->this_ecu_tp_cm.number_of_packages_being_transmitted = (j1939->this_ecu_tp_cm.total_message_size_being_transmitted)/7;			/* set number of packages, where each package will transmit up to 7 bytes */
-		if (j1939->this_ecu_tp_cm.total_message_size_being_transmitted % 7 > 0) {
-			j1939->this_ecu_tp_cm.number_of_packages_being_transmitted++;	/* add extra frame if data rolls over */
-		}
+		j1939->this_ecu_tp_cm.number_of_packages_being_transmitted = SAE_J1939_Transport_Protocol_GetNumberOfPackages(j1939->this_ecu_tp_cm.total_message_size_being_transmitted);
 
 		/* Load lamp data to first two bytes */
 		j1939->this_ecu_tp_dt.data[0] = (j1939->this_dm.dm2.SAE_lamp_status_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_lamp_status_red_stop << 4) | (j1939->this_dm.dm2.SAE_lamp_status_amber_warning << 2) | (j1939->this_dm.dm2.SAE_lamp_status_protect_lamp);
 		j1939->this_ecu_tp_dt.data[1] = (j1939->this_dm.dm2.SAE_flash_lamp_malfunction_indicator << 6) | (j1939->this_dm.dm2.SAE_flash_lamp_red_stop << 4) | (j1939->this_dm.dm2.SAE_flash_lamp_amber_warning << 2) | (j1939->this_dm.dm2.SAE_flash_lamp_protect_lamp);
 		/* Load DTCs into TP data package */
 		uint8_t i;
-		for (i = 0; i < j1939->this_ecu_tp_cm.total_message_size_being_transmitted; i++){
+		for (i = 0; i < j1939->this_dm.errors_dm2_active; i++){
 			j1939->this_ecu_tp_dt.data[i*4 + 2] = j1939->this_dm.dm2.SPN[i];
 			j1939->this_ecu_tp_dt.data[i*4 + 3] = j1939->this_dm.dm2.SPN[i] >> 8;
 			j1939->this_ecu_tp_dt.data[i*4 + 4] = ((j1939->this_dm.dm2.SPN[i] >> 11) & 0b11100000) | j1939->this_dm.dm2.FMI[i];


### PR DESCRIPTION
- fix DM1 and DM2 TP payload packing to iterate by active DTC count
- use shared TP packet-count calculation for DM2 multi-packet responses
- fix TP.DT CTS window handling to send all requested packets in each CTS window
- preserve DA=0xFF for DM1/DM2 request handling so broadcast requests use BAM
- accept TP.CM and TP.DT frames with both 0x18 and 0x1C priority variants
- keep DM1/DM2 behavior aligned with expected CMDT and BAM flows